### PR TITLE
Don't use message content by a helper as a ticket setup question answer

### DIFF
--- a/commands/ticket.js
+++ b/commands/ticket.js
@@ -12,6 +12,13 @@ module.exports = {
       return;
     }
 
+    // If message was by an admin, don't count as message
+    // answering ticket question and just return.
+    let roles = message.member.roles.cache;
+    if (roles.find((r) => r.name === "Admin") || roles.find((r) => r.name === "Helper")) {
+      return;
+    }
+
     const Keyv = require("keyv");
     const Discord = require("discord.js");
     ticketID = message.channel.name.toLowerCase().replace("ticket-", "");


### PR DESCRIPTION
If an admin/helper messages in ticket whilst MR BOT is still asking questions, MR BOT will ignore it and continue waiting for the response by a non helper persons.

Useful for when someone doesn't respond to MR BOT (all the meanies) and a helper wants to @ them to notify them the ticket is open still without having to `!stop` or ruin the questioning.

